### PR TITLE
add CE mark wikipedia link

### DIFF
--- a/faq.md
+++ b/faq.md
@@ -65,7 +65,7 @@ flowchart TD
 
 #### Q: What is the Cyber Resilience Act (CRA)?
 
-The Cyber Resilience Act (CRA) is a new EU Regulation that aims to safeguard consumers and businesses who use software or products with digital components. It creates mandatory cybersecurity requirements for manufacturers and retailers that extend throughout the product lifecycle and the whole software supply chain (including all open source dependencies and transitive dependencies) and helps consumers and business identify such products through the CE mark.
+The Cyber Resilience Act (CRA) is a new EU Regulation that aims to safeguard consumers and businesses who use software or products with digital components. It creates mandatory cybersecurity requirements for manufacturers and retailers that extend throughout the product lifecycle and the whole software supply chain (including all open source dependencies and transitive dependencies) and helps consumers and business identify such products through the [CE mark](https://en.wikipedia.org/wiki/CE_marking).
 
 #### Q: Where is the official text of the CRA?
 


### PR DESCRIPTION
Suspect most non-Europeans (and even many Europeans?) don’t know what the CE mark is so adding a link to Wikipedia.