### PR TITLE
Add GitHub workflow to notify cra.orcwg.org on push

### DIFF
--- a/.github/workflows/notify-cra-website.yml
+++ b/.github/workflows/notify-cra-website.yml
@@ -11,24 +11,26 @@ jobs:
 
     steps:
       - name: Send repository dispatch to cra.orcwg.org
-        uses: peter-evans/repository-dispatch@v3
-        with:
-          # Fine-grained PAT for cra.orcwg.org repository
-          # Required permissions:
+        run: |
+          # Send a repository_dispatch event to trigger the cra.orcwg.org rebuild workflow
+          # This uses the GitHub REST API to send a custom webhook event
+          #
+          # Required secret: WEBSITE_DISPATCH_TOKEN
+          # Token configuration:
+          #   - Resource owner: orcwg (the organization)
           #   - Repository access: Only cra.orcwg.org
-          #   - Contents: Read & Write
-          #   - Metadata: Read (auto-selected)
-          token: ${{ secrets.WEBSITE_DISPATCH_TOKEN }}
-
-          # Target repository that will build and publish to cra.orcwg.org
-          # This workflow triggers a build in cra.orcwg.org which:
-          #   1. Pulls latest content from cra-hub
-          #   2. Builds the 11ty website
-          #   3. Publishes to GitHub Pages
-          repository: orcwg/cra.orcwg.org
-
-          # Event type that cra.orcwg.org will listen for
-          event-type: cra-hub-update
-
-          # Send commit information to the target repository
-          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}", "repository": "${{ github.repository }}", "sender": "${{ github.actor }}", "message": "${{ github.event.head_commit.message }}", "timestamp": "${{ github.event.head_commit.timestamp }}"}'
+          #   - Permissions:
+          #       - Contents: Read & Write (required for repository_dispatch)
+          #       - Metadata: Read (auto-selected)
+          #
+          # The target workflow in cra.orcwg.org will:
+          #   1. Pull latest content from cra-hub
+          #   2. Build the 11ty website
+          #   3. Publish to GitHub Pages at https://cra.orcwg.org
+          curl -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.WEBSITE_DISPATCH_TOKEN }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/orcwg/cra.orcwg.org/dispatches \
+            -d '{"event_type":"cra-hub-update","client_payload":{"ref":"${{ github.ref }}","sha":"${{ github.sha }}","repository":"${{ github.repository }}","sender":"${{ github.actor }}","message":"${{ github.event.head_commit.message }}","timestamp":"${{ github.event.head_commit.timestamp }}"}}'


### PR DESCRIPTION
### Summary
This PR adds a GitHub Actions workflow that automatically notifies the `cra.orcwg.org` repository when changes are pushed to the `main` branch. This enables automatic rebuilding and deployment of the website whenever content in `cra-hub` is updated.

### Workflow Details
- **Trigger**: Runs on every push to the `main` branch
- **Action**: Sends a `repository_dispatch` event to `orcwg/cra.orcwg.org`
- **Payload**: Includes commit metadata (ref, sha, repository, sender, message, timestamp)
- **Target workflow**: Triggers the cra.orcwg.org repository to:
  1. Pull latest content from cra-hub
  2. Build the 11ty website
  3. Publish to GitHub Pages at https://cra.orcwg.org

### Required Setup: Organization-Owned Fine-Grained PAT

To enable this workflow, an **organization administrator** must create or approve a fine-grained Personal Access Token with the following configuration:

#### Token Configuration
- **Resource owner**: `orcwg` (the organization)
- **Token name**: `CRA Hub to Website Dispatch` (or similar descriptive name)
- **Expiration**: Recommended 1 year (or per org policy)
- **Repository access**: 
  - ✅ **Only select repositories**
  - ✅ Select **only** `orcwg/cra.orcwg.org`
- **Repository permissions**:
  - ✅ **Contents**: Read and write
  - ✅ **Metadata**: Read-only (automatically selected)

#### Why These Permissions?
- **Contents: Write** is required because `repository_dispatch` triggers workflow runs in the target repository, which GitHub treats as a content modification action
- **Metadata: Read** is automatically included and required for basic repository access
- No other permissions are needed or should be granted (principle of least privilege)

#### Adding the Token to Repository Secrets
Once the token is created/approved:
1. Copy the generated token value
2. Go to this repository's Settings → Secrets and variables → Actions
3. Create a new repository secret:
   - **Name**: `WEBSITE_DISPATCH_TOKEN`
   - **Value**: [paste the generated token]

### Security Considerations
✅ Uses fine-grained token (not classic PAT with broad `repo` scope)  
✅ Token has access to only one repository (`cra.orcwg.org`)  
✅ Token is organization-owned (not tied to individual user)  
✅ Minimal permissions (only what's needed for repository dispatch)  

### Testing
Once the token secret is configured, the workflow will automatically trigger on the next push to `main`. You can verify it's working by:
1. Checking the Actions tab for successful workflow runs
2. Confirming that the `cra.orcwg.org` repository receives the dispatch event and rebuilds