### PR TITLE
More precise terminology for exploited vulnerability and severe incident

### DIFF
--- a/faq/stewards/notification-obligations.md
+++ b/faq/stewards/notification-obligations.md
@@ -13,7 +13,7 @@ Per [[Article 24(3)]], _open-source software stewards_ are subject to a subset o
 
 The table below provides an actionable summary of those notification and information obligations that accounts for stewards not necessarily being aware of who their users are nor being able to reach out to them individually.
 
-| Steward support level | Notify actively exploited vulnerabilities[^1] | Notify sever incidents[^2] | General announcement[^3] | Message known users[^3] |
+| Steward support level | Notify actively exploited vulnerabilities[^1] | Notify severe incidents[^2] | General announcement[^3] | Message known users[^3] |
 | - |:-:|:-:|:-:|:-: |
 | Provides non-technical support only | N/A | N/A | N/A | N/A |
 | + provides IT infrastructure | N/A | ✅ | ✅ | N/A |

--- a/faq/stewards/notification-obligations.md
+++ b/faq/stewards/notification-obligations.md
@@ -13,7 +13,7 @@ Per [[Article 24(3)]], _open-source software stewards_ are subject to a subset o
 
 The table below provides an actionable summary of those notification and information obligations that accounts for stewards not necessarily being aware of who their users are nor being able to reach out to them individually.
 
-| Steward support level | Notify vulnerabilities[^1] | Notify incidents[^2] | General announcement[^3] | Message known users[^3] |
+| Steward support level | Notify actively exploited vulnerabilities[^1] | Notify sever incidents[^2] | General announcement[^3] | Message known users[^3] |
 | - |:-:|:-:|:-:|:-: |
 | Provides non-technical support only | N/A | N/A | N/A | N/A |
 | + provides IT infrastructure | N/A | ✅ | ✅ | N/A |


### PR DESCRIPTION
The table currently refers simply to “vulnerabilities” and “incidents”, whereas the CRA notification obligations apply specifically to “actively exploited vulnerabilities” and “severe incidents”. These distinctions are quite significant, as not every vulnerability or incident triggers a notification obligation. It might therefore be helpful to use the more precise terminology in the table.